### PR TITLE
Side Bar and Pop Up Hot Fixes

### DIFF
--- a/style.css
+++ b/style.css
@@ -1382,8 +1382,8 @@ body.dark {
   border: none;
   border-radius: 0.5rem;
   color: var(--bg-black100);
-  width: 45px;
-  height: 45px;
+  width: 28px;
+  height: 26px;
   transition: 0.3s ease;
   font-size: 1rem;
   cursor: pointer;
@@ -1419,7 +1419,7 @@ body.dark {
   border: none;
   background-color: transparent;
   width: 100%;
-  height: 100%;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -1430,6 +1430,7 @@ body.dark {
 
 .menu .optionsBar .menuItem .menuOption:hover {
   background-color: rgb(132, 0, 255);
+  
 }
 .menu .optionsBar .menuItem .menuOption i {
   width: 45px;
@@ -1500,12 +1501,20 @@ body.dark {
   background-color: transparent;
   outline: none;
   border: none;
-  border-radius: 0.5rem;
+  border-radius: 30%; 
   color: var(--bg-black100);
-  width: 100%;
-  height: 45px;
+  width: 25px; 
+  height: 30px;
   transition: 0.3s ease;
   font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menu.open .themeBar div button {
+  width: 200px; 
+  border-radius: .5rem; 
 }
 
 .menu .themeBar div button:hover {
@@ -1603,7 +1612,8 @@ background-repeat: no-repeat;
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.45); 
+  backdrop-filter: blur(6px); 
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Now the four icons below the menu icon has the same container with his respective border radius to mantain the same esthetic from the side bar. 
The menu icon also has a border radius now
<img width="113" height="281" alt="image" src="https://github.com/user-attachments/assets/16125bbb-2a54-41dc-9c2b-29473b463b22" />

<img width="167" height="307" alt="image" src="https://github.com/user-attachments/assets/9256dedd-6a3f-4543-8278-01fdf4a8883a" />
<img width="422" height="324" alt="image" src="https://github.com/user-attachments/assets/ca6f1dc5-6206-452a-9c79-0f06855bd1cf" />

And also was added a "blurring" to the pop up to highlight the pop up information
<img width="1903" height="878" alt="image" src="https://github.com/user-attachments/assets/8cac5b0b-9bf0-499e-ad30-5c85fab4b542" />
